### PR TITLE
FIX: Fatal error in wp_affiliate_log_debug()

### DIFF
--- a/pmpro-wp-affiliate-platform.php
+++ b/pmpro-wp-affiliate-platform.php
@@ -9,6 +9,20 @@ Author URI: http://www.strangerstudios.com
 		 
 Both Paid Memberships Pro (http://wordpress.org/extend/plugins/paid-memberships-pro/) and WP Affiliate Platform (http://www.tipsandtricks-hq.com/wordpress-affiliate/) must be installed and activated.
 */
+
+/**
+ * Temporary function to deal with missing affilaite_log_debug functionality
+ * @param string $text - The debug message
+ * @param boolean $show - Whether to actually log something (or not)
+ */
+if (!function_exists('wp_affiliate_log_debug')) {
+	function wp_affiliate_log_debug( $text, $show ) {
+		
+		if (true === $show) {
+			error_log($text);
+		}
+	}
+}
 /*
 	Track affiliates after checkout.
 */


### PR DESCRIPTION
wp_affiliate_log_debug() function seems to have gone missing or has been renamed w/o us knowing it. Worked around it with a quick & dirty call to error_log().
